### PR TITLE
Move from IvoryCKEditorBundle to FOSCKEditorBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "behat/symfony2-extension": "^2.1",
         "bossa/phpspec2-expect": "^2.0|^3.0",
         "doctrine/doctrine-bundle": "^1.6",
-        "egeloen/ckeditor-bundle": "^5.0",
+        "friendsofsymfony/ckeditor-bundle": "dev-master",
         "ext-pdo_sqlite": "*",
         "fsi/datagrid": "^2.0@dev",
         "fsi/datagrid-bundle": "^2.0@dev",

--- a/features/fixtures/project/app/AppKernel.php
+++ b/features/fixtures/project/app/AppKernel.php
@@ -20,7 +20,7 @@ class AppKernel extends Kernel
             new Knp\Bundle\GaufretteBundle\KnpGaufretteBundle(),
             new FSi\Bundle\ResourceRepositoryBundle\FSiResourceRepositoryBundle(),
             new FSi\Bundle\AdminTranslatableBundle\FSiAdminTranslatableBundle(),
-            new Ivory\CKEditorBundle\IvoryCKEditorBundle(),
+            new FOS\CKEditorBundle\FOSCKEditorBundle(),
 
             new FSi\FixturesBundle\FSiFixturesBundle(),
         ];

--- a/features/fixtures/project/src/FSi/FixturesBundle/Admin/Event.php
+++ b/features/fixtures/project/src/FSi/FixturesBundle/Admin/Event.php
@@ -98,7 +98,7 @@ class Event extends TranslatableCRUDElement
         }
         $formType = TypeSolver::getFormType('Symfony\Component\Form\Extension\Core\Type\FormType', 'form');
         $textType = TypeSolver::getFormType('Symfony\Component\Form\Extension\Core\Type\TextType', 'text');
-        $ckeditorType = TypeSolver::getFormType('Ivory\CKEditorBundle\Form\Type\CKEditorType', 'ckeditor');
+        $ckeditorType = TypeSolver::getFormType('FOS\CKEditorBundle\Form\Type\CKEditorType', 'ckeditor');
         $collectionType = TypeSolver::getFormType('Symfony\Component\Form\Extension\Core\Type\CollectionType', 'collection');
         $removableFileType = TypeSolver::getFormType(
             'FSi\Bundle\DoctrineExtensionsBundle\Form\Type\FSi\RemovableFileType',

--- a/vagrant/provisioning/site.yml
+++ b/vagrant/provisioning/site.yml
@@ -37,7 +37,7 @@
     - name: copy ckeditor-bundle's public resources
       file:
         src: /var/www/admin-translatable-bundle/vendor/egeloen/ckeditor-bundle/Resources/public
-        dest: /var/www/admin-translatable-bundle/features/fixtures/project/web/bundles/ivoryckeditor
+        dest: /var/www/admin-translatable-bundle/features/fixtures/project/web/bundles/fosckeditor
         owner: vagrant
         group: vagrant
         state: link

--- a/vagrant/provisioning/site.yml
+++ b/vagrant/provisioning/site.yml
@@ -36,7 +36,7 @@
         state: link
     - name: copy ckeditor-bundle's public resources
       file:
-        src: /var/www/admin-translatable-bundle/vendor/egeloen/ckeditor-bundle/Resources/public
+        src: /var/www/admin-translatable-bundle/vendor/friendsofsymfony/ckeditor-bundle/Resources/public
         dest: /var/www/admin-translatable-bundle/features/fixtures/project/web/bundles/fosckeditor
         owner: vagrant
         group: vagrant


### PR DESCRIPTION
Hi,

We took over [IvoryCKEditorBundle](https://github.com/egeloen/IvoryCKEditorBundle) and now it is under [FriendsOfSymfony](https://github.com/FriendsOfSymfony) wing and it is renamed to [FOSCKEditorBundle](https://github.com/FriendsOfSymfony/FOSCKEditorBundle).

We are helping active libraries that are depending on `IvoryCKEditorBundle` migrate to `FOSCKEditorBundle`.

The Bundle will be released in the next few days, do not merge until the bundle gets released so we can change the version in the composer.

Thank you for your time.