### PR TITLE
Prevent accessing null variables when checking for translatable DataGrid column

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,14 @@ sudo: required
 addons:
     firefox: "47.0.1"
 
-services:
-    - xvfb
+services: xvfb
 
 matrix:
     include:
         - php: 7.1
           env:
               - COMPOSER_FLAGS='--prefer-lowest'
-        - php: 7.3
+        - php: 7.4
 
 before_install:
     - phpenv config-rm xdebug.ini

--- a/DataGrid/Extension/ColumnType/Translatable.php
+++ b/DataGrid/Extension/ColumnType/Translatable.php
@@ -20,6 +20,7 @@ use FSi\DoctrineExtensions\Translatable\TranslatableListener;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\PropertyAccess\PropertyPathInterface;
+use function get_class;
 
 class Translatable extends ColumnAbstractTypeExtension
 {

--- a/composer.json
+++ b/composer.json
@@ -38,9 +38,8 @@
         "fsi/datagrid": "^2.0",
         "fsi/datasource": "^2.0",
         "fsi/resource-repository-bundle": "^2.0",
-        "phpspec/phpspec": "^5.0",
-        "phpspec/prophecy": "^1.7",
-        "sensiolabs/behat-page-object-extension": "^3.0@dev",
+        "phpspec/phpspec": "^5.0|^6.0",
+        "sensiolabs/behat-page-object-extension": "^2.1",
         "symfony/browser-kit": "^3.4|^4.0",
         "symfony/console": "^3.4|^4.0",
         "symfony/css-selector": "^3.4|^4.0",
@@ -48,7 +47,7 @@
         "symfony/dom-crawler": "^3.4|^4.0",
         "symfony/var-dumper": "^3.4|^4.0",
         "twig/twig": "^2.0",
-        "symfony/phpunit-bridge": "^4.3"
+        "symfony/phpunit-bridge": "^5.0"
     },
     "config": {
         "bin-dir": "vendor/bin"


### PR DESCRIPTION
`Translatable` tries to check whether an object is translated, but if it is not an entity, it throws a 500 because it was not checked whether an EntityManager instance was returned for the object.